### PR TITLE
"fix overlay not being displayed when console collapsed/folded"

### DIFF
--- a/Assets/Console/Console.cs
+++ b/Assets/Console/Console.cs
@@ -177,7 +177,10 @@ public class Console : MonoBehaviour
         }
 
         if (m_ConsoleFoldout <= 0.0f)
+        {
+            m_DebugOverlay.TickLateUpdate();
             return;
+        }
 
         var yoffset = -(float)m_Height * (1.0f - m_ConsoleFoldout) - 2.0f;
         m_DebugOverlay._DrawRect(0, 0 + yoffset, m_Width, m_Height, m_BackgroundColor);


### PR DESCRIPTION
When writing text to the overlay (e.g. DebugOverlay.Write), the text is not displayed if the console window is collapsed. I'm not familiar with the code base, so I leave it to your discretion whether this very simple fix is appropriate. :)